### PR TITLE
depend on scribble-lib version 1.16

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,8 +3,10 @@
 (define collection "fancy-app")
 (define scribblings
   '(("main.scrbl" () (library) "fancy-app")))
+
 (define deps '("base"))
+
 (define build-deps
   '("rackunit-lib"
     "racket-doc"
-    "scribble-lib"))
+    ["scribble-lib" #:version "1.16"]))

--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,8 @@
 (define scribblings
   '(("main.scrbl" () (library) "fancy-app")))
 
-(define deps '("base"))
+(define deps
+  '(["base" #:version "6.4"]))
 
 (define build-deps
   '("rackunit-lib"


### PR DESCRIPTION
`scribble/example` was added to scribble-lib in version 1.16.