### PR TITLE
Add tests and fix tooltip issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+compiled/
+/doc/

--- a/info.rkt
+++ b/info.rkt
@@ -5,5 +5,6 @@
   '(("main.scrbl" () (library) "fancy-app")))
 (define deps '("base"))
 (define build-deps
-  '("racket-doc"
+  '("rackunit-lib"
+    "racket-doc"
     "scribble-lib"))

--- a/main.rkt
+++ b/main.rkt
@@ -2,9 +2,15 @@
 
 (require (for-syntax racket/base))
 
+(define-for-syntax (make-tooltip stx id msg)
+  (define pos (syntax-position id))
+  (define span (syntax-span id))
+  (syntax-property
+   stx
+   'mouse-over-tooltips
+   (and pos span (vector id (sub1 pos) (sub1 (+ pos span)) msg))))
+
 (define-syntax (-app stx)
-  (define pos (syntax-position stx))
-  (define span (syntax-span stx))
   (syntax-case stx ()
     [(app arg ...)
      (let loop ([args (syntax->list #'(arg ...))] [ids null] [result null])
@@ -12,35 +18,32 @@
          [(and (null? args) (null? ids))
           (datum->syntax #'here `(#%app ,@(reverse result)) stx stx)]
          [(null? args)
-          (syntax-property
+          (make-tooltip
            (datum->syntax #'here
                           `(lambda ,(reverse ids)
                              ,(datum->syntax #'here `(#%app ,@(reverse result)) stx stx))
                           stx stx)
-           'mouse-over-tooltips
-           (and pos span
-                (vector
-                 stx
-                 pos
-                 (+ pos span)
-                 (format "this application is automatically a function using _"))))]
+           stx
+           "this application is automatically a function using _")]
          [(and (identifier? (car args)) (free-identifier=? (car args) #'_))
           (let* ([_-id (car args)]
-                 [_-pos (syntax-position _-id)]
-                 [_-span (syntax-span _-id)]
                  [id (car (generate-temporaries '(_)))]
                  [tmp
-                  (syntax-property 
-                   (syntax-track-origin
-                    id (car args) #'_)
-                   'mouse-over-tooltips
-                   (and _-pos _-span
-                        (vector id
-                                (sub1 _-pos)
-                                (sub1 (+ _-pos _-span))
-                                "_ is the parameter to the anonymous function")))])
+                  (make-tooltip
+                   (syntax-track-origin id _-id #'_)
+                   _-id
+                   "_ is the parameter to the anonymous function")])
             (loop (cdr args) (cons tmp ids) (cons tmp result)))]
          [else
           (loop (cdr args) ids (cons (car args) result))]))]))
 
 (provide (rename-out [-app #%app]))
+
+(module+ test
+  (require rackunit)
+  (define (f . xs) xs)
+  (check-equal? (-app (-app f _ 1 _ _ 4) 0 2 3) '(0 1 2 3 4))
+  (check-equal? (-app list 1 2 3) '(1 2 3))
+  (define (g x #:y y) (- x y))
+  (check-equal? (-app (-app g #:y 10 _) 100) 90)
+  (check-equal? (-app (-app g _ #:y 10) 100) 90))


### PR DESCRIPTION
The tooltip for the function application is wrong because of off-by-one
error (missing `sub1`). Also, the first item in the vector shouldn't be
the generated identifier because it has no source location. This PR fixes
both issues. The PR also adds tests.

A much more elegant version (which uses `syntax/parse`) is at https://github.com/sorawee/fancy-app/blob/travis-binsearch/main.rkt. Unfortunately, it only works for Racket version >= 7.0 (https://travis-ci.com/sorawee/fancy-app/builds/114532667), while this package originally supports Racket version >= 6.4 (https://travis-ci.com/sorawee/fancy-app/builds/114534249), so I decided not to submit the `syntax/parse` one.