### PR TITLE
Preserve source locations in applications

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -4,7 +4,6 @@
 (require syntax/parse/define
          (for-syntax racket/base
                      racket/syntax
-                     syntax/parse/experimental/template
                      syntax/stx))
 
 (begin-for-syntax
@@ -24,11 +23,12 @@
 
 (define-syntax-parser @#%app
   [(_ f:expr a:arg ...+)
-   #:when (not (stx-null? (template ((?? a.id) ...))))
-   (make-tooltip (template (λ ((?@ (?? a.id) ...)) (#%app f (?? a.id a) ...)))
+   #:when (not (stx-null? #'((~? a.id) ...)))
+   #:with lambda-body-expr (syntax/loc this-syntax (#%app f (~? a.id a) ...))
+   (make-tooltip #'(λ ((~@ (~? a.id) ...)) lambda-body-expr)
                  this-syntax
                  "this application is automatically a function using _")]
-  [(_ f:expr e ...) #'(#%app f e ...)])
+  [(_ f:expr e ...) (syntax/loc this-syntax (#%app f e ...))])
 
 (module+ test
   (require rackunit)


### PR DESCRIPTION
This change improves the error messages of the following expressions in DrRacket:

```scheme
(map (1 2 3) (list 1 2 3))
(map (1 _ 3) (list 1 2 3))
```

Before this change, the error message pointed to the usage of `#%app` inside the `fancy-app` module's code. After this change, it points to the user's faulty application expression.